### PR TITLE
fix: рамка вокруг текста в кнопках.

### DIFF
--- a/features/auth/ui.py
+++ b/features/auth/ui.py
@@ -392,6 +392,7 @@ class AuthScreen(QWidget):
                     color: {TEXT_SECONDARY};
                     font-size: 11px;
                     padding: 0 8px;
+                    outline: none;
                 }}
                 QPushButton:checked {{
                     background: {ACCENT_ORANGE};
@@ -450,6 +451,7 @@ class AuthScreen(QWidget):
                     color: {TEXT_SECONDARY};
                     font-size: 10px;
                     padding: 0 6px;
+                    outline: none;
                 }}
                 QPushButton:checked {{
                     background: {OVERLAY_HEX};


### PR DESCRIPTION
Убрал рамку пунктирную: 
<img width="353" height="262" alt="python_TBkGcO4ViA" src="https://github.com/user-attachments/assets/a93e6541-2cbf-486e-ab09-eb347270d8d3" />
