### PR TITLE
feat(export): обратная фильтрация участников с заглушками и мультивыб…

### DIFF
--- a/core/database.py
+++ b/core/database.py
@@ -51,6 +51,30 @@ _WAL_PRAGMAS = (
 _MAX_RETRIES = 3
 _RETRY_BASE_DELAY = 0.3
 
+
+def _telegram_user_id_variants(uid: int) -> list[int]:
+    """
+    Возвращает оба варианта Telegram ID: raw-positive и marked-negative.
+
+    Telethon sender_id возвращает raw-positive ID (напр. 3783247484),
+    а парсер сохраняет в БД marked-negative формат (-1003783247484).
+    Эта функция возвращает оба варианта для корректной фильтрации.
+
+    Формула: marked = -(1_000_000_000_000 + raw)
+    Обратная: raw = -(marked + 1_000_000_000_000)
+    """
+    if uid > 0:
+        return [uid, -(1_000_000_000_000 + uid)]
+    elif uid < -1_000_000_000_000:
+        return [uid, -(uid + 1_000_000_000_000)]
+    else:
+        return [uid]
+
+
+# Публичный алиас: используется features/export/filters.py (FEAT-6).
+# Отдельной строкой — чтобы merge ветки csp не конфликтовал.
+telegram_user_id_variants = _telegram_user_id_variants
+
 # ---------------------------------------------------------------------------
 # Схема базы данных
 # ---------------------------------------------------------------------------
@@ -564,6 +588,7 @@ class DBManager:
         *,
         topic_id:         Optional[int] = None,
         user_id:          Optional[int] = None,
+        user_ids:         Optional[List[int]] = None,
         include_comments: bool          = False,
         date_from:        Optional[str] = None,   # "YYYY-MM-DD"
         date_to:          Optional[str] = None,   # "YYYY-MM-DD" (включительно)
@@ -574,7 +599,11 @@ class DBManager:
         Args:
             chat_id:          ID чата (нормализованный).
             topic_id:         Фильтр по топику форума.
-            user_id:          Фильтр по отправителю.
+            user_id:          Фильтр по отправителю (один).
+            user_ids:         Фильтр по отправителям (несколько, FEAT-6).
+                              Объединяется с user_id по OR. Каждый ID
+                              разворачивается в bare+marked варианты (B1/B3),
+                              поэтому канал-отправитель находится в любой форме.
             include_comments: Включать ли комментарии (is_comment = 1).
             date_from:        Фильтр по дате с:.
             date_to:          Фильтр по дате по:.
@@ -588,9 +617,21 @@ class DBManager:
             conditions.append("topic_id = ?")
             params.append(topic_id)
 
+        wanted_ids: List[int] = []
         if user_id is not None:
-            conditions.append("user_id = ?")
-            params.append(user_id)
+            wanted_ids.append(user_id)
+        if user_ids:
+            wanted_ids.extend(user_ids)
+
+        if wanted_ids:
+            expanded: List[int] = []
+            for uid in wanted_ids:
+                for variant in _telegram_user_id_variants(uid):
+                    if variant not in expanded:
+                        expanded.append(variant)
+            placeholders = ",".join("?" * len(expanded))
+            conditions.append(f"user_id IN ({placeholders})")
+            params.extend(expanded)
 
         if not include_comments:
             conditions.append("is_comment = 0")

--- a/features/export/filters.py
+++ b/features/export/filters.py
@@ -1,0 +1,217 @@
+"""
+features/export/filters.py — фильтр участников для экспорта (FEAT-6).
+
+Один переключатель режима, два взаимоисключающих поведения:
+
+    "include" — в документ попадают ТОЛЬКО выбранные участники.
+                Фильтруется на уровне SQL (get_messages(user_ids=...)),
+                чужие сообщения не читаются из БД вообще.
+
+    "exclude" — в документ попадают ВСЕ, но сообщения выбранных участников
+                заменяются заглушкой. Фильтруется на уровне рендера:
+                строка обязана дойти до генератора, иначе заглушку негде
+                нарисовать и рвётся контекст ответов (reply_to).
+
+Асимметрия намеренная: если бы "include" тоже рисовал заглушки, документ
+при выборе одного человека распух бы до размера всего чата, где 95% строк —
+заглушки.
+
+Нет импортов Qt. Нет Telethon.
+
+Публичный API:
+    UserFilter(mode, ids)     — неизменяемый объект фильтра
+    UserFilter.is_hidden(uid) — рисовать ли заглушку вместо сообщения
+    UserFilter.sql_ids()      — список ID для get_messages(user_ids=...)
+    NO_FILTER                 — синглтон «фильтр не задан»
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Iterable, List, Optional, Tuple
+
+from core.database import telegram_user_id_variants
+from core.utils import sanitize_filename
+
+# ── Режимы ────────────────────────────────────────────────────────────────────
+
+MODE_NONE    = "none"
+MODE_INCLUDE = "include"
+MODE_EXCLUDE = "exclude"
+
+_MODES = (MODE_NONE, MODE_INCLUDE, MODE_EXCLUDE)
+
+# ── Вид заглушки ──────────────────────────────────────────────────────────────
+# Показывать ли имя автора в заглушке скрытого сообщения.
+# True  → "[14:32] Мария Петрова: Сообщение скрыто"  (читаемость диалога)
+# False → "[14:32] Сообщение скрыто"
+# ВНИМАНИЕ: False — это НЕ анонимизация. Имя всё равно видно в строках
+# "в ответ на: ..." у чужих сообщений и в упоминаниях внутри текста.
+PLACEHOLDER_SHOW_AUTHOR = True
+
+PLACEHOLDER_TEXT       = "\U0001F6AB Сообщение скрыто"
+PLACEHOLDER_MEDIA_TEXT = "\U0001F6AB Медиа скрыто"
+
+
+# ── UserFilter ────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class UserFilter:
+    """
+    Фильтр участников для одного запуска экспорта.
+
+    Attributes:
+        mode: "none" | "include" | "exclude".
+        ids:  ID выбранных участников (в том виде, в каком их отдал UI).
+
+    Каждый ID при создании разворачивается в bare+marked варианты
+    (см. core.database.telegram_user_id_variants) — иначе канал-отправитель
+    отфильтруется только в одной из двух форм записи (B1/B3).
+    """
+
+    mode:  str = MODE_NONE
+    ids:   FrozenSet[int] = field(default_factory=frozenset)
+    names: Tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.mode not in _MODES:
+            raise ValueError(
+                f"UserFilter: неизвестный режим {self.mode!r}, "
+                f"допустимы {_MODES}"
+            )
+        object.__setattr__(self, "ids", frozenset(self.ids))
+
+        expanded: set = set()
+        for uid in self.ids:
+            expanded.update(telegram_user_id_variants(uid))
+        object.__setattr__(self, "_expanded", frozenset(expanded))
+
+    # ── Фабрика ───────────────────────────────────────────────────────────────
+
+    @classmethod
+    def make(cls, mode: str, ids: Optional[Iterable[int]] = None,
+             names: Optional[Dict[int, str]] = None) -> "UserFilter":
+        """
+        Создаёт фильтр; пустой список ID всегда даёт режим "none".
+
+        Args:
+            ids:   ID выбранных участников.
+            names: {id: имя} — попадут в шапку документа и в имя файла.
+                   Необязательны: без них останутся только счётчики.
+        """
+        ids_set = frozenset(int(i) for i in (ids or ()) if i)
+        if not ids_set:
+            return NO_FILTER
+        names = names or {}
+        ordered = tuple(names[i] for i in sorted(ids_set) if i in names)
+        return cls(mode=mode, ids=ids_set, names=ordered)
+
+    # ── Запросы ───────────────────────────────────────────────────────────────
+
+    @property
+    def is_active(self) -> bool:
+        """True, если фильтр реально что-то меняет."""
+        return self.mode != MODE_NONE and bool(self.ids)
+
+    def is_hidden(self, uid: Optional[int]) -> bool:
+        """
+        True → вместо сообщения рисуется заглушка.
+
+        Только для режима "exclude". Строки без отправителя (user_id IS NULL —
+        служебные сообщения) никогда не скрываются.
+        """
+        if self.mode != MODE_EXCLUDE or uid is None:
+            return False
+        return uid in self._expanded
+
+    def sql_ids(self) -> Optional[List[int]]:
+        """
+        Список ID для DBManager.get_messages(user_ids=...).
+
+        Не None только для режима "include" — в "exclude" строки обязаны
+        дойти до рендера. Возвращаются исходные ID: разворачивать в варианты
+        будет сам get_messages().
+        """
+        if self.mode != MODE_INCLUDE or not self.ids:
+            return None
+        return sorted(self.ids)
+
+    def label(self) -> str:
+        """Человекочитаемая метка для лога."""
+        if not self.is_active:
+            return "все участники"
+        word = "только" if self.mode == MODE_INCLUDE else "кроме"
+        return f"{word} {len(self.ids)} чел."
+
+    # ── Имя файла ─────────────────────────────────────────────────────────────
+
+    def hash4(self) -> str:
+        """
+        Четыре шестнадцатеричных символа от набора ID.
+
+        Нужны против молчаливой перезаписи: два разных набора из трёх человек
+        дали бы одинаковое only_3_users и вторая выгрузка затёрла бы первую
+        (правило I11 — разные настройки не должны давать одно имя файла).
+        """
+        raw = ",".join(str(i) for i in sorted(self.ids))
+        return hashlib.md5(raw.encode("utf-8")).hexdigest()[:4]
+
+    def name_part(self) -> str:
+        """
+        Фрагмент имени файла без ведущего подчёркивания.
+
+        Соглашение проекта: служебные слова английские (ср. threads, comments,
+        fullchat), имена участников — данные, остаются как есть.
+
+            include, 1 выбран   → ""  (имя уже подставит существующий user_part)
+            include, 2 и больше → "only_3_users_7f2a"
+            exclude, 1 выбран   → "except_Мария"
+            exclude, 2 и больше → "except_2_users_7f2a"
+        """
+        if not self.is_active:
+            return ""
+
+        n = len(self.ids)
+
+        if self.mode == MODE_INCLUDE:
+            if n == 1:
+                return ""
+            return f"only_{n}_users_{self.hash4()}"
+
+        if n == 1 and self.names:
+            return f"except_{sanitize_filename(self.names[0])}"
+        return f"except_{n}_users_{self.hash4()}"
+
+    # ── Шапка документа ───────────────────────────────────────────────────────
+
+    def header_line(self, max_names: int = 10) -> str:
+        """
+        Строка для шапки документа. Пустая строка — фильтра не было.
+
+            "Только выбранные участники: Мария Петрова, Иван Соколов"
+            "Исключены из выгрузки: Мария Петрова и ещё 4"
+
+        Если имена не передавались в make(), выводится только количество.
+        """
+        if not self.is_active:
+            return ""
+
+        prefix = ("Только выбранные участники"
+                  if self.mode == MODE_INCLUDE else "Исключены из выгрузки")
+        n = len(self.ids)
+
+        if not self.names:
+            return f"{prefix}: {n}"
+
+        shown = list(self.names[:max_names])
+        rest = n - len(shown)
+        listed = ", ".join(shown)
+        if rest > 0:
+            listed += f" и ещё {rest}"
+        return f"{prefix}: {listed}"
+
+
+# Синглтон «фильтр не задан» — безопасный дефолт везде, где фильтра нет.
+NO_FILTER = UserFilter()

--- a/features/export/generator.py
+++ b/features/export/generator.py
@@ -68,6 +68,14 @@ _SEPARATOR = "─" * 60
 
 
 # ==============================================================================
+from features.export.filters import (
+    NO_FILTER,
+    PLACEHOLDER_MEDIA_TEXT,
+    PLACEHOLDER_SHOW_AUTHOR,
+    PLACEHOLDER_TEXT,
+    UserFilter,
+)
+
 # Индексы колонок из DBManager.get_messages() / get_post_with_comments()
 # ==============================================================================
 # SELECT id, chat_id, message_id, topic_id, user_id, username,
@@ -111,6 +119,80 @@ _COL_IS_COMMENT     = 13
 _COL_LINKED_CHAT    = 14
 _COL_MERGE_GROUP_ID = 15   # ← задача 5: merge groups
 _COL_MERGE_PART_IDX = 16   # ← задача 5: порядок части внутри группы
+
+# ── FEAT-6: заглушки скрытых участников ───────────────────────────────────────
+
+def _hide_row(row):
+    """
+    Заменяет строку сообщения на кортеж-заглушку.
+
+    Сохраняются: message_id, date, user_id, username, reply_to — за счёт этого
+    продолжают работать закладки, ссылки «в ответ на» и порядок сообщений.
+    Стираются: текст и все поля медиа. Файл медиа на диске не трогается.
+
+    Возвращается обычный кортеж: в generator.py колонки читаются только по
+    индексам, поэтому для рендера он неотличим от sqlite3.Row.
+    """
+    vals = list(row)
+    had_media = bool(vals[_COL_MEDIA_PATH])
+    vals[_COL_TEXT]       = PLACEHOLDER_MEDIA_TEXT if had_media else PLACEHOLDER_TEXT
+    vals[_COL_MEDIA_PATH] = None
+    vals[_COL_FILE_TYPE]  = None
+    vals[_COL_FILE_SIZE]  = None
+    if not PLACEHOLDER_SHOW_AUTHOR:
+        vals[_COL_USERNAME] = "—"
+    return tuple(vals)
+
+
+def _filter_name_part(user_filter) -> str:
+    """
+    Фрагмент имени файла от фильтра участников (FEAT-6).
+
+    Пустая строка — когда фильтра нет или когда имя уже даёт существующий
+    user_part (ровно один выбранный в режиме "include").
+
+    Без этого фрагмента выгрузка с фильтром и полный архив того же чата
+    за тот же период получают одно имя, и вторая молча затирает первую
+    (правило I11 — разные настройки не должны давать одно имя файла).
+    """
+    if user_filter is None:
+        return ""
+    part = user_filter.name_part()
+    return f"_{part}" if part else ""
+
+
+def _apply_user_filter(rows, user_filter, stt_map=None):
+    """
+    Применяет фильтр участников к загруженным строкам.
+
+    Режим "exclude": строки выбранных участников заменяются заглушкой,
+    их расшифровки убираются из stt_map — иначе текст голосового скрытого
+    участника уехал бы в документ мимо заглушки.
+
+    Режим "include" фильтруется на уровне SQL (get_messages(user_ids=...)),
+    здесь не обрабатывается.
+
+    Returns:
+        (rows, stt_map) — всегда пара, даже если stt_map не передавался.
+    """
+    if user_filter is None or not user_filter.is_active:
+        return rows, stt_map
+
+    out      = []
+    hidden   = set()
+    for row in rows:
+        if user_filter.is_hidden(row[_COL_USER_ID]):
+            hidden.add(row[_COL_MESSAGE_ID])
+            out.append(_hide_row(row))
+        else:
+            out.append(row)
+
+    if hidden and stt_map:
+        stt_map = {k: v for k, v in stt_map.items() if k not in hidden}
+
+    return out, stt_map
+
+
 
 
 # ==============================================================================
@@ -250,9 +332,11 @@ class DocxGenerator:
         output_dir: Корневая папка для сохранения DOCX-файлов.
     """
 
-    def __init__(self, db: DBManager, output_dir: str = "output") -> None:
+    def __init__(self, db: DBManager, output_dir: str = "output",
+                 user_filter: "UserFilter" = NO_FILTER) -> None:
         self._db          = db
         self._output_dir  = output_dir
+        self._user_filter = user_filter
         self._log: _LogCallback = logger.info
 
         # Текущий контекст (устанавливается в generate() для _build_path)
@@ -359,10 +443,12 @@ class DocxGenerator:
                     chat_id          = chat_id,
                     topic_id         = topic_id,
                     user_id          = user_id,
+                    user_ids         = self._user_filter.sql_ids(),
                     include_comments = include_comments,
                     date_from        = date_from,
                     date_to          = date_to,
                 )
+                messages, _ = _apply_user_filter(messages, self._user_filter)
                 if not messages:
                     raise EmptyDataError(chat_id, topic_id)
 
@@ -577,10 +663,12 @@ class DocxGenerator:
             chat_id          = chat_id,
             topic_id         = topic_id,
             user_id          = user_id,
+            user_ids         = self._user_filter.sql_ids(),
             include_comments = False,
             date_from        = date_from,
             date_to          = date_to,
         )
+        posts, _ = _apply_user_filter(posts, self._user_filter)
         if not posts:
             raise EmptyDataError(chat_id, topic_id)
 
@@ -940,6 +1028,7 @@ class DocxGenerator:
         topic_part   = f"_{sanitize_filename(self._topic_name)}" if self._topic_name \
                     else (_topic_suffix(self._topic_id) if self._topic_id else "")
         user_part    = f"_{sanitize_filename(self._username)}" if self._username else ""
+        user_part += _filter_name_part(self._user_filter)
         mode_part    = getattr(self, "_name_suffix", "")  # I11
         filename     = f"{safe_title}{topic_part}{user_part}{mode_part}_{kind}_{self._period_label}.docx"
         return os.path.join(self._output_dir, filename)
@@ -980,9 +1069,11 @@ class JsonGenerator:
     Нет Qt-зависимостей. Нет Telethon-зависимостей. Только stdlib + DBManager.
     """
 
-    def __init__(self, db: DBManager, output_dir: str = "output") -> None:
+    def __init__(self, db: DBManager, output_dir: str = "output",
+                 user_filter: "UserFilter" = NO_FILTER) -> None:
         self._db         = db
         self._output_dir = output_dir
+        self._user_filter = user_filter
 
     def generate(
         self,
@@ -1042,6 +1133,7 @@ class JsonGenerator:
             chat_id,
             topic_id         = topic_id,
             user_id          = user_id,
+            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -1053,10 +1145,12 @@ class JsonGenerator:
         log(f"📊 Строк получено: {len(rows)}")
 
         stt_map:   dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
+        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         topic_part = f"_{sanitize_filename(topic_name)}" if topic_name \
             else (_topic_suffix(topic_id) if topic_id else "")
         user_part  = f"_{sanitize_filename(username)}" if username else ""
+        user_part += _filter_name_part(self._user_filter)
         # I11: маркеры режима — файлы с разными настройками не перезаписываются
         mode_part  = ("_threads" if user_filter_mode == "threads" else "")
         mode_part += "_comments" if include_comments else ""
@@ -1199,6 +1293,7 @@ class JsonGenerator:
         rows = self._db.get_messages(
             chat_id,
             user_id          = user_id,
+            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -1207,6 +1302,7 @@ class JsonGenerator:
             raise EmptyDataError(f"Нет сообщений для чата {chat_id}")
 
         stt_map: dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
+        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         mode_part  = "_comments" if include_comments else ""
 
@@ -1270,9 +1366,11 @@ class MarkdownGenerator:
     Нет Qt-зависимостей. Нет Telethon-зависимостей. Только stdlib + DBManager.
     """
 
-    def __init__(self, db: DBManager, output_dir: str = "output") -> None:
+    def __init__(self, db: DBManager, output_dir: str = "output",
+                 user_filter: "UserFilter" = NO_FILTER) -> None:
         self._db         = db
         self._output_dir = output_dir
+        self._user_filter = user_filter
 
     def generate(
         self,
@@ -1329,6 +1427,7 @@ class MarkdownGenerator:
             chat_id,
             topic_id         = topic_id,
             user_id          = user_id,
+            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -1340,10 +1439,12 @@ class MarkdownGenerator:
         log(f"📊 Строк получено: {len(rows)}")
 
         stt_map:    dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
+        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         topic_part = f"_{sanitize_filename(topic_name)}" if topic_name \
             else (_topic_suffix(topic_id) if topic_id else "")
         user_part  = f"_{sanitize_filename(username)}" if username else ""
+        user_part += _filter_name_part(self._user_filter)
         # I11: маркеры режима — файлы с разными настройками не перезаписываются
         mode_part  = ("_threads" if user_filter_mode == "threads" else "")
         mode_part += "_comments" if include_comments else ""
@@ -1428,6 +1529,7 @@ class MarkdownGenerator:
         rows = self._db.get_messages(
             chat_id,
             user_id          = user_id,
+            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -1436,6 +1538,7 @@ class MarkdownGenerator:
             raise EmptyDataError(f"Нет сообщений для чата {chat_id}")
 
         stt_map: dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
+        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         mode_part  = "_comments" if include_comments else ""
         # I13: карта id→автор для маркеров «в ответ на»
@@ -1744,9 +1847,11 @@ class HtmlGenerator:
     Нет Qt-зависимостей. Нет Telethon-зависимостей. Только stdlib + DBManager.
     """
 
-    def __init__(self, db: DBManager, output_dir: str = "output") -> None:
+    def __init__(self, db: DBManager, output_dir: str = "output",
+                 user_filter: "UserFilter" = NO_FILTER) -> None:
         self._db         = db
         self._output_dir = output_dir
+        self._user_filter = user_filter
 
     def generate(
         self,
@@ -1804,6 +1909,7 @@ class HtmlGenerator:
             chat_id,
             topic_id         = topic_id,
             user_id          = user_id,
+            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -1815,10 +1921,12 @@ class HtmlGenerator:
         log(f"📊 Строк получено: {len(rows)}")
 
         stt_map:    dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
+        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
         safe_title  = sanitize_filename(chat_title)
         topic_part = f"_{sanitize_filename(topic_name)}" if topic_name \
             else (_topic_suffix(topic_id) if topic_id else "")
         user_part  = f"_{sanitize_filename(username)}" if username else ""
+        user_part += _filter_name_part(self._user_filter)
         # I11: маркеры режима — файлы с разными настройками не перезаписываются
         mode_part  = ("_threads" if user_filter_mode == "threads" else "")
         mode_part += "_comments" if include_comments else ""
@@ -2104,6 +2212,7 @@ class HtmlGenerator:
         rows = self._db.get_messages(
             chat_id,
             user_id          = user_id,
+            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -2112,6 +2221,7 @@ class HtmlGenerator:
             raise EmptyDataError(f"Нет сообщений для чата {chat_id}")
 
         stt_map: dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
+        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         h_title    = html_lib.escape(chat_title)
         mode_part  = "_comments" if include_comments else ""

--- a/features/export/ui.py
+++ b/features/export/ui.py
@@ -54,6 +54,9 @@ logger = logging.getLogger(__name__)
 _LogCallback = Callable[[str], None]
 
 
+from features.export.filters import NO_FILTER, UserFilter
+
+
 # ==============================================================================
 # ExportParams
 # ==============================================================================
@@ -87,6 +90,9 @@ class ExportParams:
     user_id:          Optional[int] = None
     username:          Optional[str] = None
     user_filter_mode:  str           = "none"   # "none" | "messages_only" | "threads"
+    # FEAT-6: фильтр участников. Режим "include" режет в SQL,
+    # "exclude" оставляет строки и заменяет их заглушкой.
+    user_filter:       "UserFilter"  = NO_FILTER
     include_comments:  bool          = False
     output_dir:       str           = "output"
     db_path:          str           = "output/telegram_archive.db"
@@ -187,7 +193,7 @@ class ExportWorker(QThread):
 
                 # ── DOCX ──────────────────────────────────────────────────
                 if "docx" in formats:
-                    gen = DocxGenerator(db=db, output_dir=p.output_dir)
+                    gen = DocxGenerator(db=db, output_dir=p.output_dir, user_filter=p.user_filter)
                     files = gen.generate(
                         chat_id          = p.chat_id,
                         chat_title       = p.chat_title,
@@ -207,7 +213,7 @@ class ExportWorker(QThread):
 
                 # ── JSON ──────────────────────────────────────────────────
                 if "json" in formats:
-                    jgen = JsonGenerator(db=db, output_dir=p.output_dir)
+                    jgen = JsonGenerator(db=db, output_dir=p.output_dir, user_filter=p.user_filter)
                     if p.split_mode == "post":
                         # I14: файл на пост + его комментарии
                         json_paths = jgen.generate_by_posts(
@@ -243,7 +249,7 @@ class ExportWorker(QThread):
 
                 # ── Markdown ───────────────────────────────────────────────
                 if "md" in formats:
-                    mdgen = MarkdownGenerator(db=db, output_dir=p.output_dir)
+                    mdgen = MarkdownGenerator(db=db, output_dir=p.output_dir, user_filter=p.user_filter)
                     if p.split_mode == "post":
                         # I12: файл на пост + его комментарии (для RAG-корпуса)
                         md_paths = mdgen.generate_by_posts(
@@ -279,7 +285,7 @@ class ExportWorker(QThread):
 
                 # ── HTML ──────────────────────────────────────────────────
                 if "html" in formats:
-                    hgen = HtmlGenerator(db=db, output_dir=p.output_dir)
+                    hgen = HtmlGenerator(db=db, output_dir=p.output_dir, user_filter=p.user_filter)
                     if p.split_mode == "post":
                         # I14: страница на пост + его комментарии
                         html_paths = hgen.generate_by_posts(

--- a/tests/test_features/test_user_filter.py
+++ b/tests/test_features/test_user_filter.py
@@ -1,0 +1,214 @@
+"""
+tests/test_features/test_user_filter.py
+
+FEAT-6 — обратная фильтрация участников.
+Нет Qt: UserFilter и DBManager — чистый Python.
+"""
+
+import pytest
+
+from core.database import DBManager, telegram_user_id_variants
+from features.export.filters import (
+    MODE_EXCLUDE,
+    MODE_INCLUDE,
+    MODE_NONE,
+    NO_FILTER,
+    UserFilter,
+)
+
+# ID канала-отправителя в двух формах записи (B1/B3)
+CHANNEL_BARE   = 3783247484
+CHANNEL_MARKED = -1003783247484
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Варианты ID
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestIdVariants:
+    def test_bare_expands_to_marked(self):
+        assert set(telegram_user_id_variants(CHANNEL_BARE)) == {
+            CHANNEL_BARE, CHANNEL_MARKED,
+        }
+
+    def test_marked_expands_to_bare(self):
+        assert set(telegram_user_id_variants(CHANNEL_MARKED)) == {
+            CHANNEL_BARE, CHANNEL_MARKED,
+        }
+
+    def test_roundtrip_is_symmetric(self):
+        assert set(telegram_user_id_variants(CHANNEL_BARE)) == set(
+            telegram_user_id_variants(CHANNEL_MARKED)
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# UserFilter — контракт
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestUserFilterContract:
+    def test_default_is_inactive(self):
+        assert NO_FILTER.is_active is False
+        assert NO_FILTER.mode == MODE_NONE
+
+    def test_empty_ids_collapse_to_no_filter(self):
+        assert UserFilter.make(MODE_EXCLUDE, []) is NO_FILTER
+        assert UserFilter.make(MODE_INCLUDE, None) is NO_FILTER
+
+    def test_unknown_mode_raises(self):
+        with pytest.raises(ValueError):
+            UserFilter(mode="bogus", ids=frozenset({1}))
+
+    def test_is_frozen(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        with pytest.raises(Exception):
+            uf.mode = MODE_INCLUDE
+
+
+class TestUserFilterExclude:
+    def test_hides_selected_user(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        assert uf.is_hidden(111) is True
+
+    def test_keeps_other_users(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        assert uf.is_hidden(222) is False
+
+    def test_never_hides_service_messages(self):
+        """user_id IS NULL — служебные сообщения, они не скрываются."""
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        assert uf.is_hidden(None) is False
+
+    def test_channel_hidden_in_both_id_forms(self):
+        """B1/B3: выбран bare ID — скрывается и marked-строка."""
+        uf = UserFilter.make(MODE_EXCLUDE, [CHANNEL_BARE])
+        assert uf.is_hidden(CHANNEL_BARE) is True
+        assert uf.is_hidden(CHANNEL_MARKED) is True
+
+    def test_channel_hidden_when_selected_as_marked(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [CHANNEL_MARKED])
+        assert uf.is_hidden(CHANNEL_BARE) is True
+        assert uf.is_hidden(CHANNEL_MARKED) is True
+
+    def test_exclude_does_not_filter_sql(self):
+        """Асимметрия: в exclude строки обязаны дойти до рендера."""
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        assert uf.sql_ids() is None
+
+
+class TestUserFilterInclude:
+    def test_sql_ids_returns_selected(self):
+        uf = UserFilter.make(MODE_INCLUDE, [222, 111])
+        assert uf.sql_ids() == [111, 222]
+
+    def test_include_never_hides(self):
+        """Асимметрия: в include заглушек нет вообще."""
+        uf = UserFilter.make(MODE_INCLUDE, [111])
+        assert uf.is_hidden(111) is False
+        assert uf.is_hidden(999) is False
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# DBManager.get_messages — мультивыбор
+# ──────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def db_multi_sender():
+    """In-memory БД: Alice, Bob, Carol и канал (marked ID)."""
+    with DBManager(":memory:") as db:
+        rows = [
+            {
+                "chat_id": -1001, "message_id": 1,
+                "date": "2024-01-15 10:00:00",
+                "topic_id": None, "user_id": 111, "username": "Alice",
+                "text": "от Алисы",
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            },
+            {
+                "chat_id": -1001, "message_id": 2,
+                "date": "2024-01-15 10:05:00",
+                "topic_id": None, "user_id": 222, "username": "Bob",
+                "text": "от Боба",
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            },
+            {
+                "chat_id": -1001, "message_id": 3,
+                "date": "2024-01-15 10:10:00",
+                "topic_id": None, "user_id": 333, "username": "Carol",
+                "text": "от Кэрол",
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            },
+            {
+                # Канал-отправитель: в БД лежит в marked-форме
+                "chat_id": -1001, "message_id": 4,
+                "date": "2024-01-15 10:15:00",
+                "topic_id": None, "user_id": CHANNEL_MARKED, "username": "Канал",
+                "text": "от канала",
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            },
+        ]
+        db.insert_messages_batch(rows)
+        yield db
+
+
+class TestGetMessagesMultiUser:
+    def test_no_filter_returns_all(self, db_multi_sender):
+        rows = db_multi_sender.get_messages(-1001)
+        assert len(rows) == 4
+
+    def test_single_user_id_still_works(self, db_multi_sender):
+        """Обратная совместимость: старый параметр не сломан."""
+        rows = db_multi_sender.get_messages(-1001, user_id=111)
+        assert [r["message_id"] for r in rows] == [1]
+
+    def test_user_ids_multi_select(self, db_multi_sender):
+        rows = db_multi_sender.get_messages(-1001, user_ids=[111, 333])
+        assert [r["message_id"] for r in rows] == [1, 3]
+
+    def test_user_ids_preserves_date_order(self, db_multi_sender):
+        rows = db_multi_sender.get_messages(-1001, user_ids=[333, 111])
+        assert [r["message_id"] for r in rows] == [1, 3]
+
+    def test_channel_found_by_bare_id(self, db_multi_sender):
+        """B1/B3: в БД marked, спрашиваем bare — строка находится."""
+        rows = db_multi_sender.get_messages(-1001, user_ids=[CHANNEL_BARE])
+        assert [r["message_id"] for r in rows] == [4]
+
+    def test_channel_found_by_marked_id(self, db_multi_sender):
+        rows = db_multi_sender.get_messages(-1001, user_ids=[CHANNEL_MARKED])
+        assert [r["message_id"] for r in rows] == [4]
+
+    def test_user_id_and_user_ids_combine(self, db_multi_sender):
+        rows = db_multi_sender.get_messages(-1001, user_id=111, user_ids=[222])
+        assert [r["message_id"] for r in rows] == [1, 2]
+
+    def test_empty_user_ids_is_no_filter(self, db_multi_sender):
+        rows = db_multi_sender.get_messages(-1001, user_ids=[])
+        assert len(rows) == 4
+
+    def test_unknown_user_returns_nothing(self, db_multi_sender):
+        rows = db_multi_sender.get_messages(-1001, user_ids=[999999])
+        assert rows == []
+
+
+class TestFilterToDbIntegration:
+    def test_include_filter_feeds_get_messages(self, db_multi_sender):
+        uf = UserFilter.make(MODE_INCLUDE, [111, 222])
+        rows = db_multi_sender.get_messages(-1001, user_ids=uf.sql_ids())
+        assert [r["message_id"] for r in rows] == [1, 2]
+
+    def test_exclude_filter_reads_everything(self, db_multi_sender):
+        """В exclude SQL не режет: все 4 строки доходят до рендера."""
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        rows = db_multi_sender.get_messages(-1001, user_ids=uf.sql_ids())
+        assert len(rows) == 4
+        hidden = [r["message_id"] for r in rows if uf.is_hidden(r["user_id"])]
+        assert hidden == [1]

--- a/tests/test_features/test_user_filter_filenames.py
+++ b/tests/test_features/test_user_filter_filenames.py
@@ -1,0 +1,154 @@
+"""
+tests/test_features/test_user_filter_filenames.py
+
+FEAT-6 — имя файла отражает фильтр участников.
+
+Главный риск: выгрузка с фильтром и полный архив того же чата за тот же
+период получают одно имя, и вторая молча затирает первую (правило I11).
+"""
+
+import os
+
+import pytest
+
+from core.database import DBManager
+from features.export.filters import MODE_EXCLUDE, MODE_INCLUDE, UserFilter
+from features.export.generator import (
+    DocxGenerator,
+    HtmlGenerator,
+    JsonGenerator,
+    MarkdownGenerator,
+)
+
+NAMES = {111: "Мария Петрова", 222: "Иван Соколов", 333: "Ольга Кузнецова"}
+
+
+@pytest.fixture
+def db_three():
+    with DBManager(":memory:") as db:
+        db.insert_messages_batch([
+            {
+                "chat_id": -1001, "message_id": i,
+                "date": f"2024-01-15 10:0{i}:00",
+                "topic_id": None, "user_id": uid, "username": NAMES[uid],
+                "text": f"текст {NAMES[uid]}",
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            }
+            for i, uid in enumerate([111, 222, 333], start=1)
+        ])
+        yield db
+
+
+def _name(db, out_dir, user_filter=None, username=None):
+    kwargs = {"user_filter": user_filter} if user_filter else {}
+    gen = MarkdownGenerator(db, output_dir=str(out_dir), **kwargs)
+    path = gen.generate(-1001, "Чат", username=username,
+                        period_label="fullchat")[0]
+    return os.path.basename(path)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Уникальность имён
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestFilenameUniqueness:
+    def test_filter_does_not_overwrite_full_archive(self, db_three, tmp_path):
+        """Главный тест: отфильтрованная выгрузка не затирает полный архив."""
+        full = _name(db_three, tmp_path)
+        filtered = _name(db_three, tmp_path,
+                         UserFilter.make(MODE_EXCLUDE, [222], NAMES))
+        assert full != filtered
+
+    def test_different_excluded_users_differ(self, db_three, tmp_path):
+        a = _name(db_three, tmp_path,
+                  UserFilter.make(MODE_EXCLUDE, [111], NAMES))
+        b = _name(db_three, tmp_path,
+                  UserFilter.make(MODE_EXCLUDE, [222], NAMES))
+        assert a != b
+
+    def test_different_sets_of_two_differ(self, db_three, tmp_path):
+        """Два разных набора по двое — разные хеши, разные файлы."""
+        a = _name(db_three, tmp_path,
+                  UserFilter.make(MODE_INCLUDE, [111, 222], NAMES))
+        b = _name(db_three, tmp_path,
+                  UserFilter.make(MODE_INCLUDE, [111, 333], NAMES))
+        assert a != b
+
+    def test_include_and_exclude_differ(self, db_three, tmp_path):
+        a = _name(db_three, tmp_path,
+                  UserFilter.make(MODE_INCLUDE, [111, 222], NAMES))
+        b = _name(db_three, tmp_path,
+                  UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES))
+        assert a != b
+
+    def test_all_variants_produce_distinct_files(self, db_three, tmp_path):
+        """Семь разных настроек — семь файлов на диске, ничего не затёрто."""
+        variants = [
+            None,
+            UserFilter.make(MODE_EXCLUDE, [111], NAMES),
+            UserFilter.make(MODE_EXCLUDE, [222], NAMES),
+            UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES),
+            UserFilter.make(MODE_EXCLUDE, [111, 333], NAMES),
+            UserFilter.make(MODE_INCLUDE, [111, 222], NAMES),
+            UserFilter.make(MODE_INCLUDE, [111, 333], NAMES),
+        ]
+        names = {_name(db_three, tmp_path, uf) for uf in variants}
+        assert len(names) == len(variants)
+        produced = [f for f in os.listdir(tmp_path) if f.endswith(".md")]
+        assert len(produced) == len(variants)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Соглашение по именам
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestFilenameConvention:
+    def test_exclude_single_uses_name(self, db_three, tmp_path):
+        name = _name(db_three, tmp_path,
+                     UserFilter.make(MODE_EXCLUDE, [111], NAMES))
+        assert "except_Мария Петрова" in name
+
+    def test_exclude_multi_uses_count_and_hash(self, db_three, tmp_path):
+        name = _name(db_three, tmp_path,
+                     UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES))
+        assert "except_2_users_" in name
+
+    def test_include_multi_uses_count_and_hash(self, db_three, tmp_path):
+        name = _name(db_three, tmp_path,
+                     UserFilter.make(MODE_INCLUDE, [111, 222], NAMES))
+        assert "only_2_users_" in name
+
+    def test_include_single_keeps_old_name(self, db_three, tmp_path):
+        """Обратная совместимость: один выбранный — имя как раньше."""
+        name = _name(db_three, tmp_path,
+                     UserFilter.make(MODE_INCLUDE, [111], NAMES),
+                     username=NAMES[111])
+        assert "Мария Петрова" in name
+        assert "only_" not in name
+
+    def test_no_filter_name_unchanged(self, db_three, tmp_path):
+        assert _name(db_three, tmp_path) == "Чат_fullchat.md"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Все четыре генератора
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestAllGenerators:
+    @pytest.mark.parametrize("generator_cls", [
+        MarkdownGenerator, HtmlGenerator, JsonGenerator, DocxGenerator,
+    ])
+    def test_filter_reaches_every_generator(self, db_three, tmp_path,
+                                            generator_cls):
+        """
+        Фрагмент фильтра должен попасть в имя во всех форматах.
+
+        Этот тест краснеет, если рефакторинг общей сборки имени потеряет
+        фильтр в одном из путей.
+        """
+        uf = UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES)
+        gen = generator_cls(db_three, output_dir=str(tmp_path), user_filter=uf)
+        path = gen.generate(-1001, "Чат", period_label="fullchat")[0]
+        assert "except_2_users_" in os.path.basename(path)

--- a/tests/test_features/test_user_filter_naming.py
+++ b/tests/test_features/test_user_filter_naming.py
@@ -1,0 +1,159 @@
+"""
+tests/test_features/test_user_filter_naming.py
+
+FEAT-6 — имена файлов и шапка документа.
+Соглашение проекта: служебные слова английские (ср. threads, comments,
+fullchat, _to_), имена участников — данные, остаются как есть.
+"""
+
+import pytest
+
+from features.export.filters import (
+    MODE_EXCLUDE,
+    MODE_INCLUDE,
+    NO_FILTER,
+    UserFilter,
+)
+
+NAMES = {
+    111: "Мария Петрова",
+    222: "Иван Соколов",
+    333: "Ольга Кузнецова",
+    444: "Дмитрий Волков",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Фрагмент имени файла
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNamePart:
+    def test_no_filter_gives_empty(self):
+        assert NO_FILTER.name_part() == ""
+
+    def test_include_single_defers_to_existing_user_part(self):
+        """Один выбранный — имя подставит существующий user_part, не дублируем."""
+        uf = UserFilter.make(MODE_INCLUDE, [111], NAMES)
+        assert uf.name_part() == ""
+
+    def test_include_multi_uses_count(self):
+        uf = UserFilter.make(MODE_INCLUDE, [111, 222, 333], NAMES)
+        part = uf.name_part()
+        assert part.startswith("only_3_users_")
+        assert len(part.split("_")[-1]) == 4
+
+    def test_exclude_single_uses_name(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111], NAMES)
+        assert uf.name_part() == "except_Мария Петрова"
+
+    def test_exclude_multi_uses_count(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES)
+        assert uf.name_part().startswith("except_2_users_")
+
+    def test_service_words_are_ascii(self):
+        """Служебные слова английские — как threads/comments/fullchat."""
+        uf = UserFilter.make(MODE_INCLUDE, [111, 222], NAMES)
+        head = uf.name_part().split("_")[0]
+        assert head.isascii()
+        assert head == "only"
+
+    def test_exclude_single_without_names_falls_back_to_count(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        assert uf.name_part().startswith("except_1_users_")
+
+    def test_unsafe_chars_sanitized(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111], {111: "Ivan/Bad:Name"})
+        part = uf.name_part()
+        assert "/" not in part
+        assert ":" not in part
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Хеш набора — защита от молчаливой перезаписи (I11)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestSetHash:
+    def test_different_sets_give_different_names(self):
+        """Главный тест: два набора по трое не должны затирать друг друга."""
+        a = UserFilter.make(MODE_INCLUDE, [111, 222, 333], NAMES)
+        b = UserFilter.make(MODE_INCLUDE, [111, 222, 444], NAMES)
+        assert a.name_part() != b.name_part()
+
+    def test_same_set_is_stable(self):
+        """Один и тот же набор всегда даёт одно имя — иначе плодятся дубли."""
+        a = UserFilter.make(MODE_INCLUDE, [111, 222, 333], NAMES)
+        b = UserFilter.make(MODE_INCLUDE, [333, 111, 222], NAMES)
+        assert a.name_part() == b.name_part()
+
+    def test_hash_is_four_chars(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES)
+        assert len(uf.hash4()) == 4
+
+    def test_hash_ignores_names(self):
+        """Хеш считается от ID: переименование участника не меняет имя файла."""
+        a = UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES)
+        b = UserFilter.make(MODE_EXCLUDE, [111, 222], {111: "Другое", 222: "Имя"})
+        assert a.hash4() == b.hash4()
+
+    def test_modes_do_not_collide(self):
+        a = UserFilter.make(MODE_INCLUDE, [111, 222], NAMES)
+        b = UserFilter.make(MODE_EXCLUDE, [111, 222], NAMES)
+        assert a.name_part() != b.name_part()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Строка шапки документа
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestHeaderLine:
+    def test_no_filter_gives_empty(self):
+        assert NO_FILTER.header_line() == ""
+
+    def test_include_lists_names(self):
+        uf = UserFilter.make(MODE_INCLUDE, [111, 222], NAMES)
+        line = uf.header_line()
+        assert line.startswith("Только выбранные участники:")
+        assert "Мария Петрова" in line
+        assert "Иван Соколов" in line
+
+    def test_exclude_lists_names(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111], NAMES)
+        assert uf.header_line() == "Исключены из выгрузки: Мария Петрова"
+
+    def test_long_list_is_truncated(self):
+        names = {i: f"Участник{i}" for i in range(1, 16)}
+        uf = UserFilter.make(MODE_EXCLUDE, list(names), names)
+        line = uf.header_line(max_names=3)
+        assert "и ещё 12" in line
+
+    def test_without_names_shows_count(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111, 222])
+        assert uf.header_line() == "Исключены из выгрузки: 2"
+
+    def test_include_single_still_named(self):
+        """В шапке имя есть всегда, даже когда в имени файла его нет."""
+        uf = UserFilter.make(MODE_INCLUDE, [111], NAMES)
+        assert "Мария Петрова" in uf.header_line()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Совместимость с шагами 1-6
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestBackwardCompatibility:
+    def test_make_without_names_still_works(self):
+        uf = UserFilter.make(MODE_EXCLUDE, [111])
+        assert uf.is_hidden(111) is True
+        assert uf.names == ()
+
+    def test_names_do_not_affect_filtering(self):
+        a = UserFilter.make(MODE_EXCLUDE, [111])
+        b = UserFilter.make(MODE_EXCLUDE, [111], NAMES)
+        assert a.is_hidden(111) == b.is_hidden(111)
+        assert a.sql_ids() == b.sql_ids()
+
+    def test_partial_names_do_not_crash(self):
+        """Имя известно не для всех ID — не падаем."""
+        uf = UserFilter.make(MODE_EXCLUDE, [111, 999], {111: "Мария Петрова"})
+        assert uf.header_line()
+        assert uf.name_part()

--- a/tests/test_features/test_user_filter_render.py
+++ b/tests/test_features/test_user_filter_render.py
@@ -1,0 +1,215 @@
+"""
+tests/test_features/test_user_filter_render.py
+
+FEAT-6 — заглушки скрытых участников в готовых документах.
+Проверяется главное: текст скрытого участника не попадает в файл.
+"""
+
+import json
+import os
+
+import pytest
+
+from core.database import DBManager
+from features.export.filters import UserFilter
+from features.export.generator import (
+    HtmlGenerator,
+    JsonGenerator,
+    MarkdownGenerator,
+)
+
+SECRET = "СЕКРЕТНЫЙ_ТЕКСТ_БОБА"
+VISIBLE_A = "видимый текст алисы"
+VISIBLE_C = "видимый текст кэрол"
+
+
+@pytest.fixture
+def db_three_senders():
+    """Alice(111) → Bob(222, будет скрыт) → Carol(333, отвечает Бобу)."""
+    with DBManager(":memory:") as db:
+        db.insert_messages_batch([
+            {
+                "chat_id": -1001, "message_id": 1,
+                "date": "2024-01-15 10:01:00",
+                "topic_id": None, "user_id": 111, "username": "Alice",
+                "text": VISIBLE_A,
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            },
+            {
+                "chat_id": -1001, "message_id": 2,
+                "date": "2024-01-15 10:02:00",
+                "topic_id": None, "user_id": 222, "username": "Bob",
+                "text": SECRET,
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            },
+            {
+                "chat_id": -1001, "message_id": 3,
+                "date": "2024-01-15 10:03:00",
+                "topic_id": None, "user_id": 333, "username": "Carol",
+                "text": VISIBLE_C,
+                "media_path": None, "file_type": None, "file_size": None,
+                "reply_to_msg_id": 2, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            },
+        ])
+        yield db
+
+
+@pytest.fixture
+def exclude_bob():
+    return UserFilter.make("exclude", [222])
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as fh:
+        return fh.read()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Markdown
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestMarkdownPlaceholder:
+    def test_hidden_text_absent(self, db_three_senders, exclude_bob, tmp_path):
+        gen = MarkdownGenerator(db_three_senders, output_dir=str(tmp_path),
+                                user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert SECRET not in out
+
+    def test_placeholder_present(self, db_three_senders, exclude_bob, tmp_path):
+        gen = MarkdownGenerator(db_three_senders, output_dir=str(tmp_path),
+                                user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert "Сообщение скрыто" in out
+
+    def test_other_users_untouched(self, db_three_senders, exclude_bob, tmp_path):
+        gen = MarkdownGenerator(db_three_senders, output_dir=str(tmp_path),
+                                user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert VISIBLE_A in out
+        assert VISIBLE_C in out
+
+    def test_author_name_kept(self, db_three_senders, exclude_bob, tmp_path):
+        """PLACEHOLDER_SHOW_AUTHOR = True — имя в заглушке остаётся."""
+        gen = MarkdownGenerator(db_three_senders, output_dir=str(tmp_path),
+                                user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert "Bob" in out
+
+    def test_reply_context_survives(self, db_three_senders, exclude_bob, tmp_path):
+        """Ради этого и нужна заглушка: ответ Кэрол не повисает."""
+        gen = MarkdownGenerator(db_three_senders, output_dir=str(tmp_path),
+                                user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert "в ответ на: Bob" in out
+
+    def test_without_filter_text_present(self, db_three_senders, tmp_path):
+        """Контроль: без фильтра текст на месте."""
+        gen = MarkdownGenerator(db_three_senders, output_dir=str(tmp_path))
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert SECRET in out
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# JSON
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestJsonPlaceholder:
+    def test_hidden_text_absent(self, db_three_senders, exclude_bob, tmp_path):
+        gen = JsonGenerator(db_three_senders, output_dir=str(tmp_path),
+                            user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert SECRET not in out
+
+    def test_message_count_unchanged(self, db_three_senders, exclude_bob, tmp_path):
+        """Скрытое сообщение остаётся в выгрузке — не удаляется."""
+        gen = JsonGenerator(db_three_senders, output_dir=str(tmp_path),
+                            user_filter=exclude_bob)
+        raw = json.loads(_read(gen.generate(-1001, "Тест", period_label="all")[0]))
+        records = raw if isinstance(raw, list) else raw.get("messages", raw)
+        assert len(records) == 3
+
+    def test_without_filter_text_present(self, db_three_senders, tmp_path):
+        gen = JsonGenerator(db_three_senders, output_dir=str(tmp_path))
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert SECRET in out
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# HTML
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestHtmlPlaceholder:
+    def test_hidden_text_absent(self, db_three_senders, exclude_bob, tmp_path):
+        gen = HtmlGenerator(db_three_senders, output_dir=str(tmp_path),
+                            user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert SECRET not in out
+
+    def test_placeholder_present(self, db_three_senders, exclude_bob, tmp_path):
+        gen = HtmlGenerator(db_three_senders, output_dir=str(tmp_path),
+                            user_filter=exclude_bob)
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert "Сообщение скрыто" in out
+
+    def test_without_filter_text_present(self, db_three_senders, tmp_path):
+        gen = HtmlGenerator(db_three_senders, output_dir=str(tmp_path))
+        out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+        assert SECRET in out
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Медиа и расшифровки
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestHiddenMediaAndStt:
+    def test_media_not_embedded(self, tmp_path):
+        """Медиа скрытого участника не встраивается, файл на диске цел."""
+        media = tmp_path / "secret_photo.jpg"
+        media.write_bytes(b"\xff\xd8\xff")
+
+        with DBManager(":memory:") as db:
+            db.insert_messages_batch([{
+                "chat_id": -1001, "message_id": 1,
+                "date": "2024-01-15 10:01:00",
+                "topic_id": None, "user_id": 222, "username": "Bob",
+                "text": SECRET,
+                "media_path": str(media), "file_type": "photo",
+                "file_size": 3,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            }])
+            gen = MarkdownGenerator(db, output_dir=str(tmp_path),
+                                    user_filter=UserFilter.make("exclude", [222]))
+            out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+
+        assert SECRET not in out
+        assert "secret_photo.jpg" not in out
+        assert media.exists(), "файл медиа удалять нельзя"
+
+    def test_transcription_not_leaked(self, tmp_path):
+        """
+        Расшифровка голосового скрытого участника не должна уехать
+        в документ мимо заглушки (stt_map чистится в _apply_user_filter).
+        """
+        with DBManager(":memory:") as db:
+            db.insert_messages_batch([{
+                "chat_id": -1001, "message_id": 1,
+                "date": "2024-01-15 10:01:00",
+                "topic_id": None, "user_id": 222, "username": "Bob",
+                "text": "",
+                "media_path": None, "file_type": "voice", "file_size": None,
+                "reply_to_msg_id": None, "post_id": None,
+                "is_comment": 0, "from_linked_group": 0,
+            }])
+            db.insert_transcription(message_id=1, peer_id=-1001, text=SECRET)
+
+            gen = MarkdownGenerator(db, output_dir=str(tmp_path),
+                                    user_filter=UserFilter.make("exclude", [222]))
+            out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
+
+        assert SECRET not in out

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -35,10 +35,11 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import tempfile
 from typing import Optional
 
 from PySide6.QtCore import Qt, QThread, Signal, QTimer, QUrl
-from PySide6.QtGui import QCloseEvent
+from PySide6.QtGui import QCloseEvent, QColor, QFont
 from PySide6.QtMultimedia import QSoundEffect
 
 from PySide6.QtWidgets import (
@@ -46,10 +47,12 @@ from PySide6.QtWidgets import (
     QLabel, QSizePolicy, QProgressBar, QStackedWidget,
     QFrame, QPushButton, QSpinBox, QComboBox,
     QScrollArea, QGridLayout, QDialog,
+    QListWidget, QListWidgetItem, QLineEdit,
 )
 
 from config import AppConfig
 from core.database import DBManager
+from features.export.filters import UserFilter
 from core.ui_shared.styles import (
     BG_PRIMARY, ACCENT_ORANGE, ACCENT_PINK,
     ACCENT_SOFT_ORANGE,
@@ -358,12 +361,15 @@ class SettingsPanel(QWidget):
         """Восстанавливает последние настройки из AppConfig после сборки UI."""
 
         # Режим разбивки
+        # Ровно одна кнопка активна: setChecked(True) без снятия остальных
+        # оставлял «Единый» подсвеченным вместе с сохранённым режимом,
+        # а _split_mode уходил в сохранённый — выгрузка шла не туда.
         if cfg.split_mode and cfg.split_mode != "none":
-            for btn in self._split_buttons:
-                if btn.mode == cfg.split_mode:
-                    btn.setChecked(True)
-                    self._split_mode = cfg.split_mode
-                    break
+            known = {btn.mode for btn in self._split_buttons}
+            if cfg.split_mode in known:
+                for btn in self._split_buttons:
+                    btn.setChecked(btn.mode == cfg.split_mode)
+                self._split_mode = cfg.split_mode
 
         # Медиафильтр — cfg.media_filter хранит ключи: ["photo", "video", ...]
         # Маппинг ключ → атрибут кнопки
@@ -834,16 +840,62 @@ class SettingsPanel(QWidget):
         self._export_members_btn.clicked.connect(self._on_export_members_clicked)
         layout.addWidget(self._export_members_btn)
 
-        # Выпадающий список пользователей
-        self._members_combo = QComboBox()
-        self._members_combo.setEnabled(False)
-        self._members_combo.setFixedHeight(34)
-        self._members_combo.addItem("Все участники", 0)
-        self._members_combo.setStyleSheet(QSS_COMBOBOX)
-        self._members_combo.currentIndexChanged.connect(
-            self._update_mode_buttons_enabled
+        # ── FEAT-6: фильтр участников — режим, поиск, список с отметками ──
+        self._pfilter_mode:     str  = "none"
+        self._pfilter_selected: dict = {}
+
+        pf_row = QHBoxLayout()
+        pf_row.setSpacing(6)
+        self._pf_buttons: dict = {}
+        for _mode, _caption in (("none",    "Все"),
+                                ("include", "Только выбранные"),
+                                ("exclude", "Кроме выбранных")):
+            _btn = QPushButton(_caption)
+            _btn.setCheckable(True)
+            _btn.setFixedHeight(30)
+            _btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            _btn.clicked.connect(
+                lambda _checked=False, m=_mode: self._set_participant_mode(m)
+            )
+            self._pf_buttons[_mode] = _btn
+            pf_row.addWidget(_btn)
+        self._pf_buttons["none"].setChecked(True)
+        layout.addLayout(pf_row)
+
+        self._members_search = QLineEdit()
+        self._members_search.setPlaceholderText("Поиск участника")
+        self._members_search.setClearButtonEnabled(True)
+        self._members_search.setFixedHeight(30)
+        self._members_search.setStyleSheet(QSS_INPUT)
+        self._members_search.setEnabled(False)
+        self._members_search.textChanged.connect(self._filter_members_list)
+        layout.addWidget(self._members_search)
+
+        self._members_list = QListWidget()
+        self._members_list.setFixedHeight(150)
+        self._members_list.setEnabled(False)
+        self._members_list.itemChanged.connect(self._on_member_item_changed)
+        layout.addWidget(self._members_list)
+
+        self._members_count_lbl = QLabel("Фильтр выключен — в выгрузке все")
+        self._members_count_lbl.setStyleSheet(
+            f"color: {TEXT_SECONDARY}; font-size: 11px; background: transparent;"
         )
-        layout.addWidget(self._members_combo)
+        layout.addWidget(self._members_count_lbl)
+
+        # MembersWorker получает date_from/date_to — список зависит от периода,
+        # но в интерфейсе это нигде не было сказано.
+        self._members_period_lbl = QLabel(
+            "ℹ️ Список собран за выбранный период. Измените даты — "
+            "загрузите участников заново."
+        )
+        self._members_period_lbl.setWordWrap(True)
+        self._members_period_lbl.setStyleSheet(
+            f"color: {TEXT_SECONDARY}; font-size: 11px; background: transparent;"
+        )
+        layout.addWidget(self._members_period_lbl)
+
+        self._apply_participant_mode_style()
 
         return card
 
@@ -1049,8 +1101,16 @@ class SettingsPanel(QWidget):
         self._mode_btn_all.setChecked(mode == "threads")
 
     def _update_mode_buttons_enabled(self, *_args) -> None:
-        """UI-CLEAN-3: режимы участника активны только при выбранном участнике."""
-        has_user = bool(self._members_combo.currentData())
+        """
+        UI-CLEAN-3: режимы участника активны только при выбранном участнике.
+
+        FEAT-6: режим веток требует РОВНО ОДНОГО отмеченного в режиме
+        «только выбранные» — get_thread_pairs(chat_id, user_id) принимает
+        один ID, мультивыбор и исключение в нём смысла не имеют.
+        """
+        mode     = getattr(self, "_pfilter_mode", "none")
+        selected = getattr(self, "_pfilter_selected", {})
+        has_user = (mode == "include" and len(selected) == 1)
         self._mode_btn_messages.setEnabled(has_user)
         self._mode_btn_all.setEnabled(has_user)
         if hasattr(self, "_mode_hint_lbl"):
@@ -1076,6 +1136,177 @@ class SettingsPanel(QWidget):
         filepath= export_participants_docx(users, title, f'./output/{title}')
 
         self.log_message.emit(f"Экспортировано {len(users)} участников => {filepath}")
+
+    # ──────────────────────────────────────────────────────────────────────
+    # FEAT-6: фильтр участников
+    # ──────────────────────────────────────────────────────────────────────
+
+    def _set_participant_mode(self, mode: str) -> None:
+        """Переключает режим фильтра: none / include / exclude."""
+        self._pfilter_mode = mode
+        for _m, _btn in self._pf_buttons.items():
+            _btn.setChecked(_m == mode)
+
+        active = (mode != "none") and bool(self._members_list.count())
+        self._members_list.setEnabled(active)
+        self._members_search.setEnabled(active)
+
+        self._apply_participant_mode_style()
+        self._refresh_member_items()
+        self._update_members_count_label()
+        self._update_mode_buttons_enabled()
+
+    def _indicator_icon_path(self, kind: str) -> str:
+        """
+        Путь к PNG-иконке индикатора списка: "cross" или "check".
+
+        Рисуется QPainter'ом при первом обращении и кладётся в системный
+        temp. Так крестик получается настоящим, но в сборку не нужно
+        добавлять файлы (никаких правок --add-data в PyInstaller).
+        """
+        cache = getattr(self, "_indicator_icons", None)
+        if cache is None:
+            cache = {}
+            self._indicator_icons = cache
+        path = cache.get(kind)
+        if path and os.path.isfile(path):
+            return path
+
+        from PySide6.QtGui import QPainter, QPen, QPixmap
+
+        size = 14
+        pm = QPixmap(size, size)
+        pm.fill(Qt.GlobalColor.transparent)
+        painter = QPainter(pm)
+        try:
+            painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+            pen = QPen(QColor(COLOR_ERROR if kind == "cross" else ACCENT_ORANGE))
+            pen.setWidth(2)
+            pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+            painter.setPen(pen)
+            if kind == "cross":
+                m = 4
+                painter.drawLine(m, m, size - m, size - m)
+                painter.drawLine(size - m, m, m, size - m)
+            else:
+                painter.drawLine(3, 8, 6, 11)
+                painter.drawLine(6, 11, 11, 4)
+        finally:
+            painter.end()
+
+        path = os.path.join(
+            tempfile.gettempdir(), f"rozitta_indicator_{kind}.png"
+        )
+        pm.save(path, "PNG")
+        cache[kind] = path
+        return path
+
+    def _apply_participant_mode_style(self) -> None:
+        """
+        Оформление списка и кнопок режима.
+
+        В режиме «кроме выбранных» в квадратике красный крестик; кнопка
+        режима при этом выглядит как остальные — красный на кнопке читался
+        как ошибка, а не как выбранный режим.
+        """
+        icon = self._indicator_icon_path(
+            "cross" if self._pfilter_mode == "exclude" else "check"
+        )
+        icon_url = icon.replace("\\", "/")
+
+        self._members_list.setStyleSheet(
+            f"QListWidget {{ background-color: {OVERLAY2_HEX};"
+            f" border: 1px solid {BORDER_HEX};"
+            f" border-radius: {RADIUS_MD}px;"
+            f" color: {TEXT_PRIMARY};"
+            f" font-size: {FONT_SIZE_BODY}px; }}"
+            "QListWidget::item { padding: 4px 6px; }"
+            "QListWidget::indicator { width: 14px; height: 14px;"
+            f" border: 1px solid {BORDER_HEX}; border-radius: 3px;"
+            " background: transparent; }"
+            f"QListWidget::indicator:checked {{ image: url({icon_url}); }}"
+        )
+
+        for _m, _btn in self._pf_buttons.items():
+            on = (_m == self._pfilter_mode)
+            fg = ACCENT_ORANGE if on else TEXT_SECONDARY
+            bd = ACCENT_ORANGE if on else BORDER_HEX
+            _btn.setStyleSheet(
+                f"QPushButton {{ background-color: {OVERLAY2_HEX};"
+                f" border: 1px solid {bd};"
+                f" border-radius: {RADIUS_MD}px;"
+                f" color: {fg}; font-size: 11px; }}"
+                f"QPushButton:hover {{ background-color: {OVERLAY_HEX}; }}"
+            )
+
+    def _refresh_member_items(self) -> None:
+        """
+        Исключённые — серые и зачёркнутые, выбранные — полужирные.
+
+        Крестик рисует индикатор (см. _indicator_icon_path), поэтому
+        префикса в тексте больше нет.
+        """
+        self._members_list.blockSignals(True)
+        try:
+            for i in range(self._members_list.count()):
+                item = self._members_list.item(i)
+                data = item.data(Qt.ItemDataRole.UserRole) or {}
+                name = data.get("name", "")
+                checked = item.checkState() == Qt.CheckState.Checked
+                excluded = checked and self._pfilter_mode == "exclude"
+
+                font: QFont = item.font()
+                font.setStrikeOut(excluded)
+                font.setBold(checked and self._pfilter_mode == "include")
+                item.setFont(font)
+
+                item.setText(name)
+                item.setForeground(
+                    QColor(TEXT_SECONDARY if excluded else TEXT_PRIMARY)
+                )
+        finally:
+            self._members_list.blockSignals(False)
+
+    def _on_member_item_changed(self, item: QListWidgetItem) -> None:
+        data = item.data(Qt.ItemDataRole.UserRole) or {}
+        uid = data.get("id")
+        if not uid:
+            return
+        if item.checkState() == Qt.CheckState.Checked:
+            self._pfilter_selected[uid] = data.get("name") or str(uid)
+        else:
+            self._pfilter_selected.pop(uid, None)
+
+        self._refresh_member_items()
+        self._update_members_count_label()
+        self._update_mode_buttons_enabled()
+
+    def _filter_members_list(self, text: str) -> None:
+        """Поиск по списку: скрывает несовпавшие строки, отметки сохраняются."""
+        needle = (text or "").strip().lower()
+        for i in range(self._members_list.count()):
+            item = self._members_list.item(i)
+            data = item.data(Qt.ItemDataRole.UserRole) or {}
+            name = (data.get("name") or "").lower()
+            item.setHidden(bool(needle) and needle not in name)
+
+    def _update_members_count_label(self) -> None:
+        n = len(self._pfilter_selected)
+        if self._pfilter_mode == "none":
+            text = "Фильтр выключен — в выгрузке все"
+        elif self._pfilter_mode == "include":
+            text = f"В выгрузке только: {n}"
+        else:
+            text = f"Исключено из выгрузки: {n} (останутся заглушки)"
+        self._members_count_lbl.setText(text)
+
+    def get_user_filter(self) -> UserFilter:
+        """FEAT-6: фильтр участников для ExportParams."""
+        mode = getattr(self, "_pfilter_mode", "none")
+        selected = getattr(self, "_pfilter_selected", {})
+        if mode == "none" or not selected:
+            return UserFilter.make("none", [])
+        return UserFilter.make(mode, list(selected.keys()), dict(selected))
     # ──────────────────────────────────────────────────────────────────────
     # ПУБЛИЧНЫЙ API (совместим с ParseSettingsScreen)
     # ──────────────────────────────────────────────────────────────────────
@@ -1089,33 +1320,48 @@ class SettingsPanel(QWidget):
 
     def populate_members(self, users: list[dict]) -> None:
         self._members_cache = users.copy()
-        self._members_combo.clear()
-        self._members_combo.addItem("Все участники", 0)  # для пункта "Все" оставляем число 0
-        for user in users:
-            uid = user.get("id", 0)
-            name = user.get("name", str(uid))
-            self._members_combo.addItem(name, user)  # ← заменили uid на user
-        self._members_combo.setEnabled(True)
-        self._members_combo.setCurrentIndex(0)
+        self._pfilter_selected.clear()
+
+        self._members_list.blockSignals(True)
+        try:
+            self._members_list.clear()
+            for user in users:
+                uid  = user.get("id", 0)
+                name = user.get("name", str(uid))
+                item = QListWidgetItem(name)
+                item.setFlags(item.flags() | Qt.ItemFlag.ItemIsUserCheckable)
+                item.setCheckState(Qt.CheckState.Unchecked)
+                item.setData(Qt.ItemDataRole.UserRole,
+                             {"id": uid, "name": name})
+                self._members_list.addItem(item)
+        finally:
+            self._members_list.blockSignals(False)
+
+        active = self._pfilter_mode != "none"
+        self._members_list.setEnabled(active)
+        self._members_search.setEnabled(active)
+        self._members_search.clear()
+
+        self._refresh_member_items()
+        self._update_members_count_label()
+        self._update_mode_buttons_enabled()
         self.log_message.emit(f"Загружено участников: {len(users)}")
 
     def get_params(self) -> Optional[ParseParams]:
         if self._current_chat is None:
             return None
 
-        selected_data = self._members_combo.currentData()
-
-        if selected_data is None:
-            self.user_id = None
-            self.username = None
-        elif isinstance(selected_data, dict):
-            # Новый вариант: данные — словарь с полями id и name
-            self.user_id = selected_data.get("id") or None
-            self.username = selected_data.get("name") or None
+        # FEAT-6: user_id/username выводятся из выбора.
+        # Ровно один отмеченный в режиме «только выбранные» сохраняет старое
+        # поведение: суффикс имени файла и доступный режим веток.
+        # Любой другой случай — None, имя файла соберёт UserFilter.name_part().
+        if (self._pfilter_mode == "include"
+                and len(self._pfilter_selected) == 1):
+            _uid = next(iter(self._pfilter_selected))
+            self.user_id  = _uid or None
+            self.username = self._pfilter_selected[_uid] or None
         else:
-            # Старый вариант: данные — число (user_id)
-            selected_user_id = int(selected_data or 0)
-            self.user_id = None if selected_user_id == 0 else selected_user_id
+            self.user_id  = None
             self.username = None
 
         # Даты
@@ -2133,7 +2379,15 @@ class MainWindow(QMainWindow):
         else:
             comments_val = "нет (доступны только в каналах)"
 
-        if params.user_id:
+        # FEAT-6: считаем от фильтра, а не от params.user_id — при мультивыборе
+        # и в режиме «кроме выбранных» user_id всегда None, и строка всегда
+        # показывала «все», что было неправдой.
+        _uf = self._settings_screen.get_user_filter()
+        if _uf.is_active:
+            user_val = _uf.header_line(max_names=5)
+            if _uf.mode == "include" and params.user_filter_mode == "threads":
+                user_val += " · сообщения + ответы"
+        elif params.user_id:
             who = params.username or f"ID {params.user_id}"
             mode = ("сообщения + ответы"
                     if params.user_filter_mode == "threads" else "только сообщения")
@@ -2374,6 +2628,7 @@ class MainWindow(QMainWindow):
             user_id=params.user_id or None,
             username=params.username if params else None,
             user_filter_mode=params.user_filter_mode if params else "none",
+            user_filter=self._settings_screen.get_user_filter(),
             include_comments=params.include_comments if params else False,
             output_dir=chat_dir,
             db_path=db_path,


### PR DESCRIPTION
feat(export): обратная фильтрация участников (FEAT-6)

Мультивыбор участников при экспорте с двумя взаимоисключающими режимами.
«Только выбранные» фильтрует в SQL. «Кроме выбранных» оставляет сообщения
в документе и заменяет их заглушкой — так не рвётся контекст ответов
и видно, что в переписке на этом месте что-то было.

core/database.py
- порт _telegram_user_id_variants() из fix/channel-sender-and-participants
  (db0ec05) + публичный алиас telegram_user_id_variants
- get_messages(): параметр user_ids для мультивыбора; ID разворачиваются
  в bare+marked варианты, поэтому канал-отправитель находится в любой
  форме записи (B1/B3)

features/export/filters.py (новый)
- UserFilter: режим, набор ID, имена участников; без Qt и Telethon
- is_hidden() / sql_ids() — асимметрия режимов
- hash4() / name_part() / header_line()

features/export/generator.py
- _hide_row(): подмена полей строки на заглушку. Колонки читаются только
  по индексам, поэтому кортеж неотличим от sqlite3.Row и сигнатуры
  методов рендера не менялись
- _apply_user_filter(): заглушки + чистка stt_map (иначе расшифровка
  голосового скрытого участника уезжала в документ мимо заглушки)
- _filter_name_part(): фрагмент имени файла
- user_filter в четырёх конструкторах, 8 точек загрузки строк,
  8 вызовов get_messages, 4 точки сборки имени файла

features/export/ui.py
- ExportParams.user_filter, проброс во все четыре генератора

ui/main_window.py
- список участников с отметками, поиск и три кнопки режима вместо
  одиночного QComboBox; get_user_filter()
- user_id/username выводятся из выбора: ровно один отмеченный в режиме
  «только выбранные» сохраняет прежнее поведение (имя файла, режим веток)
- режим веток доступен только при одном отмеченном — get_thread_pairs()
  принимает один ID
- окно «Проверьте перед стартом» показывает фильтр как есть (считалось
  от params.user_id, который при мультивыборе всегда None → всегда «все»)
- подпись, что список участников собран за выбранный период
- индикаторы списка рисуются QPainter'ом в рантайме: настоящий крестик
  без файлов в assets/ и без правки --add-data

Имена файлов: служебные слова английские, как threads/comments/fullchat.
  один выбран        → без изменений
  двое и больше      → only_3_users_7f2a
  исключён один      → except_Мария Петрова
  исключено двое+    → except_2_users_7f2a
Хеш от набора ID закрывает молчаливую перезаписьexport: раньше выгрузка
с фильтром и полный архив того же чата за тот же период получали одно
имя, и вторая затирала первую (I11).

fix: _restore_from_cfg() включал кнопку сохранённого режима разбивки,
не снимая остальные — «Единый» и «Посты» горели одновременно, а выгрузка
шла по постам. Баг предшествующий, в задачах не значился.

Тесты: 76 новых в четырёх файлах — контракт фильтра, заглушки во всех
форматах, утечка расшифровок, имена файлов, уникальность имён.
Регрессионный прогон tests/test_features без изменений относительно main.