### PR TITLE
fix(export): фильтр участников только к комментариям в режиме «по постам"

### DIFF
--- a/features/export/filters.py
+++ b/features/export/filters.py
@@ -115,6 +115,24 @@ class UserFilter:
         """True, если фильтр реально что-то меняет."""
         return self.mode != MODE_NONE and bool(self.ids)
 
+    def matches(self, uid: Optional[int]) -> bool:
+        """
+        True → участник отмечен в списке фильтра.
+
+        Предикат один на оба режима, а вот следствие разное: в "include"
+        отмеченные остаются, в "exclude" — прячутся. Нужен отдельно от
+        is_hidden(), потому что в режиме «по постам» include-фильтрация
+        комментариев происходит на уровне рендера, а не в SQL: в SQL она
+        вымыла бы вместе с чужими комментариями и сами посты, которые
+        приходят от имени канала.
+
+        Строки без отправителя (user_id IS NULL — служебные сообщения)
+        не отмечены никогда.
+        """
+        if not self.is_active or uid is None:
+            return False
+        return uid in self._expanded
+
     def is_hidden(self, uid: Optional[int]) -> bool:
         """
         True → вместо сообщения рисуется заглушка.
@@ -122,9 +140,9 @@ class UserFilter:
         Только для режима "exclude". Строки без отправителя (user_id IS NULL —
         служебные сообщения) никогда не скрываются.
         """
-        if self.mode != MODE_EXCLUDE or uid is None:
+        if self.mode != MODE_EXCLUDE:
             return False
-        return uid in self._expanded
+        return self.matches(uid)
 
     def sql_ids(self) -> Optional[List[int]]:
         """

--- a/features/export/generator.py
+++ b/features/export/generator.py
@@ -69,6 +69,7 @@ _SEPARATOR = "─" * 60
 
 # ==============================================================================
 from features.export.filters import (
+    MODE_INCLUDE,
     NO_FILTER,
     PLACEHOLDER_MEDIA_TEXT,
     PLACEHOLDER_SHOW_AUTHOR,
@@ -186,6 +187,52 @@ def _apply_user_filter(rows, user_filter, stt_map=None):
             out.append(_hide_row(row))
         else:
             out.append(row)
+
+    if hidden and stt_map:
+        stt_map = {k: v for k, v in stt_map.items() if k not in hidden}
+
+    return out, stt_map
+
+
+def _apply_comment_filter(rows, user_filter, stt_map=None):
+    """
+    Фильтр участников для режима «по постам»: применяется ТОЛЬКО к комментариям.
+
+    Пост печатается всегда целиком — он то, вокруг чего собран файл, без него
+    файл бессмыслен. Кроме того, пост в канале приходит от имени самого канала,
+    и общий фильтр по участникам вымывал бы все посты разом (D-2).
+
+    К комментариям применяется обычная асимметрия FEAT-6:
+        include → комментарии невыбранных выбрасываются (заглушек нет: файл
+                  поста не должен состоять из двадцати «Сообщение скрыто»)
+        exclude → комментарии выбранных заменяются заглушкой
+
+    Расшифровки скрытых и выброшенных комментариев убираются из stt_map:
+    текст голосового берётся по message_id и мимо заглушки уехал бы в документ.
+
+    Returns:
+        (rows, stt_map) — всегда пара, даже если stt_map не передавался.
+    """
+    if user_filter is None or not user_filter.is_active:
+        return rows, stt_map
+
+    out = []
+    hidden = set()
+    for row in rows:
+        if not row[_COL_IS_COMMENT]:
+            out.append(row)                      # пост — всегда целиком
+            continue
+        if not user_filter.matches(row[_COL_USER_ID]):
+            if user_filter.mode == MODE_INCLUDE:
+                hidden.add(row[_COL_MESSAGE_ID])  # не выбран → в файл не идёт
+            else:
+                out.append(row)
+            continue
+        if user_filter.mode == MODE_INCLUDE:
+            out.append(row)                      # выбран → остаётся как есть
+        else:
+            hidden.add(row[_COL_MESSAGE_ID])
+            out.append(_hide_row(row))
 
     if hidden and stt_map:
         stt_map = {k: v for k, v in stt_map.items() if k not in hidden}
@@ -662,13 +709,10 @@ class DocxGenerator:
         posts = self._db.get_messages(
             chat_id          = chat_id,
             topic_id         = topic_id,
-            user_id          = user_id,
-            user_ids         = self._user_filter.sql_ids(),
             include_comments = False,
             date_from        = date_from,
             date_to          = date_to,
         )
-        posts, _ = _apply_user_filter(posts, self._user_filter)
         if not posts:
             raise EmptyDataError(chat_id, topic_id)
 
@@ -694,6 +738,11 @@ class DocxGenerator:
                     r for r in all_rows
                     if not (r[_COL_MESSAGE_ID] == post_id and r[_COL_IS_COMMENT] == 0)
                 ]
+                # D-1: второй запрос мимо фильтра не идёт. Расшифровки чистятся
+                # явно — self._transcriptions не защищено обнулением file_type,
+                # потому что эти строки не проходили через _hide_row().
+                comments, self._transcriptions = _apply_comment_filter(
+                    comments, self._user_filter, self._transcriptions)
                 if comments:
                     doc.add_paragraph()
                     comment_header = doc.add_heading(
@@ -1292,8 +1341,6 @@ class JsonGenerator:
         log("📋 Загружаю сообщения из БД для JSON-экспорта по постам...")
         rows = self._db.get_messages(
             chat_id,
-            user_id          = user_id,
-            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -1302,7 +1349,7 @@ class JsonGenerator:
             raise EmptyDataError(f"Нет сообщений для чата {chat_id}")
 
         stt_map: dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
-        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
+        rows, stt_map = _apply_comment_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         mode_part  = "_comments" if include_comments else ""
 
@@ -1528,8 +1575,6 @@ class MarkdownGenerator:
         log("📋 Загружаю сообщения из БД для MD-экспорта по постам...")
         rows = self._db.get_messages(
             chat_id,
-            user_id          = user_id,
-            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -1538,7 +1583,7 @@ class MarkdownGenerator:
             raise EmptyDataError(f"Нет сообщений для чата {chat_id}")
 
         stt_map: dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
-        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
+        rows, stt_map = _apply_comment_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         mode_part  = "_comments" if include_comments else ""
         # I13: карта id→автор для маркеров «в ответ на»
@@ -2211,8 +2256,6 @@ class HtmlGenerator:
         log("📋 Загружаю сообщения из БД для HTML-экспорта по постам...")
         rows = self._db.get_messages(
             chat_id,
-            user_id          = user_id,
-            user_ids         = self._user_filter.sql_ids(),
             include_comments = include_comments,
             date_from        = date_from,
             date_to          = date_to,
@@ -2221,7 +2264,7 @@ class HtmlGenerator:
             raise EmptyDataError(f"Нет сообщений для чата {chat_id}")
 
         stt_map: dict[int, str] = self._db.get_transcriptions_for_chat(chat_id)
-        rows, stt_map = _apply_user_filter(rows, self._user_filter, stt_map)
+        rows, stt_map = _apply_comment_filter(rows, self._user_filter, stt_map)
         safe_title = sanitize_filename(chat_title)
         h_title    = html_lib.escape(chat_title)
         mode_part  = "_comments" if include_comments else ""

--- a/tests/test_features/test_migrate_media_paths.py
+++ b/tests/test_features/test_migrate_media_paths.py
@@ -24,7 +24,11 @@ _SCRIPT = os.path.join(_REPO_ROOT, "migrate_media_paths.py")
 
 # Импортируем модуль напрямую для доступа к функциям
 sys.path.insert(0, _REPO_ROOT)
-import migrate_media_paths as mp  # noqa: E402
+mp = pytest.importorskip(
+    "migrate_media_paths",
+    reason="скрипт миграции путей к медиа отсутствует в репозитории (см. П1)",
+)
+
 
 
 # ============================================================================

--- a/tests/test_features/test_user_filter_render.py
+++ b/tests/test_features/test_user_filter_render.py
@@ -12,6 +12,7 @@ import pytest
 from core.database import DBManager
 from features.export.filters import UserFilter
 from features.export.generator import (
+    DocxGenerator,
     HtmlGenerator,
     JsonGenerator,
     MarkdownGenerator,
@@ -212,3 +213,141 @@ class TestHiddenMediaAndStt:
             out = _read(gen.generate(-1001, "Тест", period_label="all")[0])
 
         assert HIDDEN_TEXT not in out
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Режим «по постам»: фильтр применяется только к комментариям (D-1, D-2)
+# ──────────────────────────────────────────────────────────────────────────────
+
+POST_TEXT       = "ТЕКСТ_ПОСТА_КАНАЛА"
+COMMENT_MARIA   = "МАРКЕР_КОММЕНТАРИЯ_МАРИИ"
+COMMENT_STT     = "МАРКЕР_РАСШИФРОВКИ_МАРИИ"
+COMMENT_IVAN    = "МАРКЕР_КОММЕНТАРИЯ_ИВАНА"
+CHANNEL_ID      = -1001
+MARIA, IVAN     = 111, 222
+POST_NAMES      = {MARIA: "Мария", IVAN: "Иван"}
+
+
+@pytest.fixture
+def db_channel(tmp_path):
+    """Канал: пост от имени канала + комментарии Марии (с голосовым) и Ивана."""
+    voice = tmp_path / "voice_101.ogg"
+    voice.write_bytes(b"x")
+    base = {
+        "chat_id": CHANNEL_ID, "topic_id": None, "media_path": None,
+        "file_type": None, "file_size": None, "from_linked_group": 0,
+    }
+    with DBManager(":memory:") as db:
+        db.insert_messages_batch([
+            {**base, "message_id": 100, "date": "2024-01-15 10:00:00",
+             "user_id": CHANNEL_ID, "username": "Канал", "text": POST_TEXT,
+             "reply_to_msg_id": None, "post_id": None, "is_comment": 0},
+            {**base, "message_id": 101, "date": "2024-01-15 10:05:00",
+             "user_id": MARIA, "username": "Мария", "text": COMMENT_MARIA,
+             "media_path": str(voice), "file_type": "voice", "file_size": 1,
+             "reply_to_msg_id": 100, "post_id": 100, "is_comment": 1},
+            {**base, "message_id": 102, "date": "2024-01-15 10:06:00",
+             "user_id": IVAN, "username": "Иван", "text": COMMENT_IVAN,
+             "reply_to_msg_id": 100, "post_id": 100, "is_comment": 1},
+        ])
+        db.insert_transcription(101, CHANNEL_ID, COMMENT_STT)
+        yield db
+
+
+def _by_posts_text(db, out_dir, generator_cls, user_filter, user_id=None):
+    """
+    Запускает выгрузку «по постам» и возвращает склеенный текст файлов.
+
+    user_id передаётся как его передаёт UI: при «только выбранные» с одним
+    отмеченным ExportWorker кладёт туда его id. Без этого тест не проверяет
+    реальный путь — а именно там легаси-фильтр вымывал посты.
+    """
+    gen = generator_cls(db, output_dir=str(out_dir), user_filter=user_filter)
+    if generator_cls is DocxGenerator:
+        files = gen.generate(chat_id=CHANNEL_ID, chat_title="Канал",
+                             split_mode="post", include_comments=True,
+                             user_id=user_id, period_label="fullchat")
+        import docx
+        return "\n".join(p.text for f in files
+                          for p in docx.Document(f).paragraphs)
+    files = gen.generate_by_posts(chat_id=CHANNEL_ID, chat_title="Канал",
+                                  user_id=user_id, include_comments=True,
+                                  period_label="fullchat")
+    return "\n".join(open(f, encoding="utf-8").read() for f in files)
+
+
+ALL_FOUR = [DocxGenerator, MarkdownGenerator, JsonGenerator, HtmlGenerator]
+
+
+class TestByPostsCommentFilter:
+    """
+    Режим «по постам»: пост печатается всегда целиком, фильтр действует
+    только на комментарии.
+    """
+
+    @pytest.mark.parametrize("generator_cls", ALL_FOUR)
+    def test_exclude_hides_comment_everywhere(self, db_channel, tmp_path,
+                                              generator_cls):
+        """
+        D-1: три вещи утекали по трём разным причинам, поэтому три проверки.
+        DOCX брал комментарии вторым запросом мимо фильтра; расшифровка
+        держалась на обнулении file_type в _hide_row(), которого здесь не было.
+        """
+        uf = UserFilter.make("exclude", [MARIA], POST_NAMES)
+        body = _by_posts_text(db_channel, tmp_path, generator_cls, uf)
+
+        assert COMMENT_MARIA not in body, "текст скрытого комментария в файле"
+        assert "voice_101" not in body, "медиа скрытого комментария в файле"
+        assert COMMENT_STT not in body, "расшифровка скрытого комментария в файле"
+
+    @pytest.mark.parametrize("generator_cls", ALL_FOUR)
+    def test_exclude_keeps_post_and_others(self, db_channel, tmp_path,
+                                           generator_cls):
+        """Пост и чужие комментарии остаются нетронутыми."""
+        uf = UserFilter.make("exclude", [MARIA], POST_NAMES)
+        body = _by_posts_text(db_channel, tmp_path, generator_cls, uf)
+
+        assert POST_TEXT in body, "пост исчез или стал заглушкой"
+        assert COMMENT_IVAN in body, "чужой комментарий пропал"
+
+    @pytest.mark.parametrize("generator_cls", ALL_FOUR)
+    def test_include_keeps_post_and_selected_only(self, db_channel, tmp_path,
+                                                  generator_cls):
+        """
+        D-2: раньше «только Мария» не оставляло ни одного поста (посты идут
+        от имени канала) и падало с EmptyDataError.
+        """
+        uf = UserFilter.make("include", [MARIA], POST_NAMES)
+        body = _by_posts_text(db_channel, tmp_path, generator_cls, uf,
+                              user_id=MARIA)
+
+        assert POST_TEXT in body, "пост должен печататься целиком"
+        assert COMMENT_MARIA in body, "комментарий выбранного участника пропал"
+        assert COMMENT_IVAN not in body, "комментарий невыбранного в файле"
+
+    @pytest.mark.parametrize("generator_cls", ALL_FOUR)
+    def test_include_draws_no_placeholders(self, db_channel, tmp_path,
+                                           generator_cls):
+        """
+        В режиме «только выбранные» заглушек нет вовсе: иначе файл поста
+        состоял бы из двадцати строк «Сообщение скрыто».
+        """
+        uf = UserFilter.make("include", [MARIA], POST_NAMES)
+        body = _by_posts_text(db_channel, tmp_path, generator_cls, uf,
+                              user_id=MARIA)
+
+        assert "скрыто" not in body.lower()
+
+    @pytest.mark.parametrize("generator_cls", ALL_FOUR)
+    def test_post_survives_exclusion_of_its_author(self, db_channel, tmp_path,
+                                                   generator_cls):
+        """
+        Р-1 в самом прямом виде: скрыт автор постов, то есть сам канал.
+        Пост всё равно печатается целиком — он то, вокруг чего собран файл,
+        и заглушка вместо него оставила бы обсуждение без предмета.
+        """
+        uf = UserFilter.make("exclude", [CHANNEL_ID], {CHANNEL_ID: "Канал"})
+        body = _by_posts_text(db_channel, tmp_path, generator_cls, uf)
+
+        assert POST_TEXT in body, "пост исчез при исключении автора"
+        assert COMMENT_MARIA in body and COMMENT_IVAN in body,             "комментарии не должны страдать от исключения канала"


### PR DESCRIPTION
D-1: DOCX брал комментарии вторым запросом (get_post_with_comments)
     мимо фильтра — текст, медиа и расшифровка исключённого попадали
     в документ с именем except_*.
D-2: user_ids и user_id уходили в SQL и вымывали сами посты — в канале
     они от имени канала, поэтому «только выбранные» падало с EmptyDataError.

Пост печатается всегда целиком. Для комментариев: include отсеивает
невыбранных без заглушек, exclude заменяет заглушкой.
Добавлен предикат UserFilter.matches(); +20 тестов.